### PR TITLE
Fix test bug

### DIFF
--- a/ch1/1.1/test/test.js
+++ b/ch1/1.1/test/test.js
@@ -35,7 +35,7 @@ describe('Client Tests', () => {
       EthCrypto.hash.keccak256(message),
     );
     it('should set successfully sign messages', () => {
-      assert.equal(client.sign(message), signature);
+      assert.equal(client.sign(EthCrypto.hash.keccak256(message)), signature);
     });
   });
 
@@ -51,7 +51,7 @@ describe('Client Tests', () => {
       Alice = new Client();
       Bob = new Client();
       Kevin = new Client();
-      signature = Alice.sign(message);
+      signature = Alice.sign(EthCrypto.hash.keccak256(message));
     });
     it('should be considered valid', () => {
       assert(


### PR DESCRIPTION
TypeError: str.startsWith is not a function is being raised when sending a non-string message to the sign function in the eth-crypto library.

This PR fixes #30 